### PR TITLE
Fixes #5 - protecting getKeys() from global use

### DIFF
--- a/src/types/db.types.ts
+++ b/src/types/db.types.ts
@@ -3,7 +3,6 @@ export interface IDatabase<K, T> {
   set(id: K, value: T): Promise<void>
   setEx(id: K, value: T, expiry: number): Promise<void>
   del(id: K): Promise<void>
-  getKeys(): Promise<[string] | undefined>
 }
 
 export type IDBKeyType = string | number | symbol

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -73,7 +73,7 @@ class SpeedCache<K extends IDBKeyType, T> implements IDatabase<K, T> {
     this.writeFile()
   }
 
-  async getKeys(): Promise<[string] | undefined> {
+  protected async getKeys(): Promise<[string] | undefined> {
     const keys = Object.keys(this.db);
     if (keys.length) {
       return keys as [string];


### PR DESCRIPTION
Fixes webcoderspeed/speed-cache#5

- getKeys() function is now not exposed for global use in routes.ts

**Reason for implementation:**
- TypeScript Interfaces can only contain 'public' properties. So, in order to protect getKeys() function, getKeys() was removed from IDatabase Interface at db.types.ts
- with the 'protected' modifier, the 'cache' in routes.ts cannot use the getKeys() function, hence protecting it from global use